### PR TITLE
解决包冲突

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-            <version>5.1.8.RELEASE</version>
+            <version>5.0.15.RELEASE</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
这道题坑了我好久。

一开始惯性思维以为是老师自建的包会冲突，报错信息也没认真看。后来发现并不是这样。就根据报错信息，找到 `spring` 的源码。然后直接傻了，这么多版本的代码，难道要一个一个人眼识别吗。但是又没好办法，不会在github上搜索什么的技能。只好从题目中给的依赖的版本开始看更新版本的 `org.springframework.http.converter.json.MappingJacksonValue` 类中的代码。连续纯人眼看了好几个版本，都没发现需要的方法。只好谷歌了一下 `getJsonpFunction`这个方法，发现 `Will be removed as of Spring Framework 5.1, use CORS instead.` 这个关键信息。就开始找老版本。终于不再报错。

流水账一样的经历描述完毕。那么问题来了，这个冲突我可以通过谷歌刚好找到了这个方法的相关信息。如果以后没有这种巧合，那么应该怎么方便快捷的判断哪个版本的代码刚好是我们想要的依赖呢。有木有快速检索之类的方法。