### PR TITLE
spring-web的5.1.8版本和4.3.6版本冲突

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,12 +21,6 @@
     </repositories>
     <dependencies>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
-            <version>5.1.8.RELEASE</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>com.github.hcsp</groupId>
             <artifactId>test-library-a</artifactId>
             <version>0.4</version>


### PR DESCRIPTION
5.1.8版本的MappingJacksonValue中的方法getJsonpFunction被去除了，但是我们的代码要用到这个方法，所以我删除了spring5.1.8版本的依赖，默认使用4.3.6版本的依赖

<!--- 你要打开的这个Pull request(PR)的类型是？默认是题目解答，如果你正在修复当前的仓库的缺陷，请选择对应的类型 -->

- [x] 这个PR解答了当前仓库中的题目（机器人会自动判题并合并当前PR）
- [ ] 这个PR修复了当前仓库中的一些代码缺陷（机器人不会判题，而是由管理员来处理当前PR）

