### PR TITLE
引用 jar 包版本冲突解决

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,12 +21,6 @@
     </repositories>
     <dependencies>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
-            <version>5.1.8.RELEASE</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>com.github.hcsp</groupId>
             <artifactId>test-library-a</artifactId>
             <version>0.4</version>


### PR DESCRIPTION
spring-web 版本 5.1.8.RELEASE 与4.3.6.RELEASE 冲突，
om.github.hcsp.a.A 类中 a 方法引用的是 4.3.6 的版本

<!--- 你要打开的这个Pull request(PR)的类型是？默认是题目解答，如果你正在修复当前的仓库的缺陷，请选择对应的类型 -->

- [x] 这个PR解答了当前仓库中的题目（机器人会自动判题并合并当前PR）
- [ ] 这个PR修复了当前仓库中的一些代码缺陷（机器人不会判题，而是由管理员来处理当前PR）

