### PR TITLE
修复spring-web版本冲突

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,12 +21,6 @@
     </repositories>
     <dependencies>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
-            <version>5.1.8.RELEASE</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>com.github.hcsp</groupId>
             <artifactId>test-library-a</artifactId>
             <version>0.4</version>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,12 @@
     </repositories>
     <dependencies>
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <version>4.3.6.RELEASE</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>com.github.hcsp</groupId>
             <artifactId>test-library-a</artifactId>
             <version>0.4</version>


### PR DESCRIPTION
因为spring-web的版本冲突导致hcsp jar包无法使用，现将spring-web 5.1.8版本删除

