### PR TITLE
fix NoSuchMethodError MappingJacksonValue.getJsonpFunction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-            <version>5.1.8.RELEASE</version>
+            <version>5.0.8.RELEASE</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
<!--- 你要打开的这个Pull request(PR)的类型是？默认是题目解答，如果你正在修复当前的仓库的缺陷，请选择对应的类型 -->

- [x] 这个PR解答了当前仓库中的题目（机器人会自动判题并合并当前PR）
- [ ] 这个PR修复了当前仓库中的一些代码缺陷（机器人不会判题，而是由管理员来处理当前PR）

@sdeleuze remove JSONP support in 5.1, which is deprecated in 4.3.x and 5.0.x branches
see Issues: https://github.com/spring-projects/spring-framework/issues/21453
